### PR TITLE
Fix IPv6 variable error in DNS script

### DIFF
--- a/set-unbound-dns.sh
+++ b/set-unbound-dns.sh
@@ -8,6 +8,11 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;36m'
 NC='\033[0m' # No Color
 
+# Initialize optional DNS variables to avoid unbound errors when IPv6
+# addresses are not provided.
+ipv6_primary_dns=""
+ipv6_secondary_dns=""
+
 # Function to display error and exit
 error_exit() {
   echo -e "${RED}ERROR: $1${NC}" >&2


### PR DESCRIPTION
## Summary
- initialize optional IPv6 DNS variables at startup

## Testing
- `shellcheck set-unbound-dns.sh`
- `bash -n set-unbound-dns.sh`

------
https://chatgpt.com/codex/tasks/task_b_687376f1b1748321a36628a85fa16bee