### PR TITLE
Improve unbound compatibility

### DIFF
--- a/set-unbound-dns.sh
+++ b/set-unbound-dns.sh
@@ -410,7 +410,15 @@ fi
 
 echo -e "\n${BLUE}=== Checking Unbound configuration ===${NC}"
 if ! unbound-checkconf; then
-  error_exit "Unbound configuration check failed. Please check the error messages above."
+  if grep -q "serve-expired-client-timeout" "$CONF_FILE"; then
+    warning "serve-expired-client-timeout is not supported. Removing the option and retrying."
+    sed -i '/serve-expired-client-timeout:/d' "$CONF_FILE"
+    if ! unbound-checkconf; then
+      error_exit "Unbound configuration check failed even after adjusting options. Please check the error messages above."
+    fi
+  else
+    error_exit "Unbound configuration check failed. Please check the error messages above."
+  fi
 fi
 
 echo -e "\n${BLUE}=== Restarting Unbound ===${NC}"


### PR DESCRIPTION
## Summary
- workaround older Unbound versions that reject `serve-expired-client-timeout`

## Testing
- `apt-get update`
- `apt-get install -y shellcheck`
- `shellcheck set-unbound-dns.sh`

------
https://chatgpt.com/codex/tasks/task_b_6875790f6f4483218ecdc87221ce383c